### PR TITLE
Removed extra "<" before bundle script tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,6 +25,6 @@
     <my-app>Loading...</my-app>
 
     <!-- Production mod -->
-    <<script src="js/bundle.min.js"></script>
+    <script src="js/bundle.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Extra < before bundle script tag was showing up on home page.
